### PR TITLE
Adds grid of thumbnails

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,1 +1,27 @@
 @import '~antd/dist/antd.css';
+
+.sider {
+  background-color: white;
+}
+
+.image-list, .tree-view, .simple-list {
+  overflow-y: auto;
+  max-height: 100%;
+  user-select: none;
+}
+
+.item-label, .item-label{
+  overflow-y: auto;
+  max-height: 100%;
+}
+
+
+.image-list .item {
+  margin: 3px;
+  display: inline-block;
+  border: 3px solid transparent;
+}
+
+.image-list .item.selected {
+  border: 3px solid blue;
+}

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ManifestCanvasInfo } from '../utils/IIIFUtils';
+
+
+class ImageListProps {
+  selectedOids: string[] = [];
+  canvasInfo: ManifestCanvasInfo[] = [];
+  onCanvasClick?: ((oid: string, shiftKey: boolean, metaKey: boolean) => void);
+}
+
+
+function ImageCanvas({ canvasInfo, selectedOids, onCanvasClick }: ImageListProps) {
+  return (
+    <div className='image-list'>
+      {canvasInfo.map((info) => {
+        return <div className={'item' + (selectedOids.includes(info.oid) ? " selected" : "")} key={info.oid} onClick={(e) => {
+          if (onCanvasClick) {
+            onCanvasClick(info.oid, e.shiftKey, e.metaKey)
+          }
+        }}>
+          <img src={info.thumbnail} alt={info.label + " " + info.oid} /><br />
+          <span className='item-index'>{(info.index + 1) + ": "}</span> <span className='item-label'>{info.label}</span>
+        </div>
+      })}
+    </div>
+  );
+}
+
+export default ImageCanvas;

--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -1,0 +1,69 @@
+export function extractIIIFLabel(obj: any, defaultValue: string = ""): string {
+  if (!obj || !obj["label"]) {
+    return defaultValue
+  }
+  let title = defaultValue;
+  let label_props = Object.getOwnPropertyNames(obj["label"]);
+  if (label_props.length > 0) {
+    title = obj["label"][label_props[0]][0]
+  }
+  return title;
+}
+
+export type ManifestCanvasInfo = {
+  label: string;
+  imageId: string;
+  oid: string;
+  thumbnail: string;
+  index: number;
+}
+
+
+export type RangeInfoType = "range" | "canvas";
+
+export type ManifestRangeInfo = {
+  type: RangeInfoType;
+  label: string;
+  id: string;
+  new: boolean;
+  contents: ManifestRangeInfo[];
+}
+
+
+export function canvasInfoFromManifest(manifestData: any): ManifestCanvasInfo[] | null {
+  let canvasInfo: ManifestCanvasInfo[] | null = null;
+  if (manifestData) {
+    canvasInfo = [];
+    let ix = 0;
+    for (let item of manifestData["items"]) {
+      let id = item["id"];
+      let thumbnail = item["thumbnail"][0]["id"];
+      let anno = item["items"]?.[0]?.["items"]?.[0];
+      let body = anno?.["body"];
+      if (body instanceof Array) {
+        body = body[0];
+      }
+      let imageId = body["id"];
+      let oid = id.split("/").pop()
+      let label = extractIIIFLabel(item, "");
+      if (label) {
+        label = [label, "(" + oid + ")"].join(": ");
+      } else {
+        label = oid;
+      }
+      canvasInfo.push({
+        label: label,
+        imageId: imageId,
+        oid: oid,
+        thumbnail: thumbnail,
+        index: ix++,
+      }
+      );
+    }
+  }
+  return canvasInfo;
+}
+
+export function rangeInfoFromManifest(manifestData: any): ManifestRangeInfo[] | null {
+  return null;
+}


### PR DESCRIPTION
# Summary
Adds a grid of thumbnail images from the manifest.

# Related Ticket
[#2159](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2159)

# Screenshot
![image](https://user-images.githubusercontent.com/36549923/183738084-c1c7fb31-903f-45f9-a8d2-c859ce68aba0.png)
