### PR TITLE
Use canvas ids load structures

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { downloadManifest, setApiKeyGlobal } from './utils/ManagementUtils';
 import TopHeader from './components/TopHeader'
 import ImageCanvas from './components/ImageCanvas'
 import LaunchModal from './components/LaunchModal';
-import { canvasInfoFromManifest, ManifestCanvasInfo, ManifestRangeInfo, ManifestRangeInfoTree, rangeInfoFromManifest } from './utils/IIIFUtils';
+import { canvasInfoFromManifest, ManifestCanvasInfo, ManifestStructureInfoTree, structureInfoFromManifest } from './utils/IIIFUtils';
 import './App.css';
 const { Sider, Content } = Layout;
 
@@ -14,7 +14,7 @@ function App() {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [loadedManifest, setLoadedManifest ] = useState<{[key: string]: any} | null>(null);
   const [canvasInfo, setCanvasInfo] = React.useState<ManifestCanvasInfo[]>([]);
-  const [rangeInfo, setRangeInfo] = React.useState<ManifestRangeInfoTree[]>([]);
+  const [structureInfo, setStructureInfo] = React.useState<ManifestStructureInfoTree[]>([]);
   const [selectedCanvasIds, setSelectedCanvasIds] = React.useState<string[]>([]);
   const [selectStart, setSelectStart] = React.useState<string | null>(null);
 
@@ -87,8 +87,8 @@ function App() {
     canvasInfo && setCanvasInfo(canvasInfo);
     setSelectStart(null);
     setSelectedCanvasIds([]);
-    let rangeInfo = rangeInfoFromManifest(loadedManifest);
-    setRangeInfo(rangeInfo || []);
+    let structureInfo = structureInfoFromManifest(loadedManifest);
+    setStructureInfo(structureInfo || []);
   }, [loadedManifest])
 
   return (
@@ -99,7 +99,7 @@ function App() {
         <Sider className="sider">
           <Tree
                 className='tree-view'
-                treeData={rangeInfo || []}
+                treeData={structureInfo || []}
             />
         </Sider>
         <Content>

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -4,13 +4,13 @@ import { useInView } from "react-intersection-observer";
 
 
 class ImageListProps {
-  selectedOids: string[] = [];
+  selectedCanvasIds: string[] = [];
   canvasInfo: ManifestCanvasInfo[] = [];
-  onCanvasClick?: ((oid: string, shiftKey: boolean, metaKey: boolean) => void);
+  onCanvasClick?: ((canvasId: string, shiftKey: boolean, metaKey: boolean) => void);
 }
 
 
-function ImageCanvas({ canvasInfo, selectedOids, onCanvasClick }: ImageListProps) {
+function ImageCanvas({ canvasInfo, selectedCanvasIds, onCanvasClick }: ImageListProps) {
 
   const { ref, inView } = useInView({
     threshold: 0,
@@ -19,9 +19,9 @@ function ImageCanvas({ canvasInfo, selectedOids, onCanvasClick }: ImageListProps
   return (
     <div className='image-list' ref={ref}>
       {canvasInfo.map((info) => {
-        return <div className={'item' + (selectedOids.includes(info.oid) ? " selected" : "")} key={info.oid} onClick={(e) => {
+        return <div className={'item' + (selectedCanvasIds.includes(info.canvasId) ? " selected" : "")} key={info.imageId} onClick={(e) => {
           if (onCanvasClick) {
-            onCanvasClick(info.oid, e.shiftKey, e.metaKey)
+            onCanvasClick(info.canvasId, e.shiftKey, e.metaKey)
           }
         }}>
           {inView && <img src={info.thumbnail} loading="lazy" alt={info.label + " " + info.oid} />}

--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -1,3 +1,6 @@
+import type { DataNode } from 'antd/es/tree';
+
+
 export function extractIIIFLabel(obj: any, defaultValue: string = ""): string {
   if (!obj || !obj["label"]) {
     return defaultValue
@@ -13,21 +16,24 @@ export function extractIIIFLabel(obj: any, defaultValue: string = ""): string {
 export type ManifestCanvasInfo = {
   label: string;
   imageId: string;
+  canvasId: string;
   oid: string;
   thumbnail: string;
   index: number;
 }
 
 
-export type RangeInfoType = "range" | "canvas";
+export type RangeInfoType = "Range" | "Canvas";
 
 export type ManifestRangeInfo = {
   type: RangeInfoType;
   label: string;
   id: string;
-  new: boolean;
-  contents: ManifestRangeInfo[];
+  newItem: boolean;
+  items: ManifestRangeInfo[];
 }
+
+export type ManifestRangeInfoTree = ManifestRangeInfo & DataNode
 
 
 export function canvasInfoFromManifest(manifestData: any): ManifestCanvasInfo[] | null {
@@ -37,14 +43,16 @@ export function canvasInfoFromManifest(manifestData: any): ManifestCanvasInfo[] 
     let ix = 0;
     for (let item of manifestData["items"]) {
       let id = item["id"];
-      let thumbnail = item["thumbnail"][0]["id"];
       let anno = item["items"]?.[0]?.["items"]?.[0];
       let body = anno?.["body"];
       if (body instanceof Array) {
         body = body[0];
       }
       let imageId = body["id"];
-      let oid = id.split("/").pop()
+      let imageIdComponents = imageId.split("/");
+      imageIdComponents[imageIdComponents.length - 3] = "!200,200";      
+      let thumbnail = imageIdComponents.join("/");
+      let oid = id.split("/").pop();
       let label = extractIIIFLabel(item, "");
       if (label) {
         label = [label, "(" + oid + ")"].join(": ");
@@ -54,6 +62,7 @@ export function canvasInfoFromManifest(manifestData: any): ManifestCanvasInfo[] 
       canvasInfo.push({
         label: label,
         imageId: imageId,
+        canvasId: id,
         oid: oid,
         thumbnail: thumbnail,
         index: ix++,
@@ -64,6 +73,38 @@ export function canvasInfoFromManifest(manifestData: any): ManifestCanvasInfo[] 
   return canvasInfo;
 }
 
-export function rangeInfoFromManifest(manifestData: any): ManifestRangeInfo[] | null {
-  return null;
+export function rangeInfoFromManifest(manifestData: any): ManifestRangeInfoTree[] | null {
+  let ranges: ManifestRangeInfoTree[] | null = null;
+  if (manifestData && manifestData["structures"]) {
+    let itemIdToLabelMap: any = {};
+    for (let item of manifestData["items"]) {
+      let id: string = item["id"];
+      let label = extractIIIFLabel(item);
+      itemIdToLabelMap[id] = label;
+    }
+    ranges = [];
+    for (let structure of manifestData["structures"]) {
+      ranges.push(recursiveExtractStructure(structure, itemIdToLabelMap))
+    }
+  }
+  return ranges;
+}
+
+function recursiveExtractStructure(structure: any, itemIdToLabelMap: any): ManifestRangeInfoTree {
+  let label = extractIIIFLabel(structure, "");
+  let id = structure["id"];
+  let type: RangeInfoType = (structure["type"] === "Canvas") ? "Canvas" : "Range";
+  let newItem = false;
+  let items = [];
+  if (type === "Range" && structure["items"]) {
+    for (let item of structure["items"]) {
+      items.push(recursiveExtractStructure(item, itemIdToLabelMap));
+    }
+  }
+  if (!label && type === "Canvas") {
+    label = itemIdToLabelMap[id] || "";
+    let idParts = id.split("/");
+    label += ": (" + idParts[idParts.length -1] + ")";
+  }
+  return {key: id, title: label, children: items, label, id, type, newItem, items};
 }

--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -23,7 +23,7 @@ export type ManifestCanvasInfo = {
 }
 
 
-export type StructureInfoType = "Structure" | "Canvas";
+export type StructureInfoType = "Range" | "Canvas";
 
 export type ManifestStructureInfo = {
   type: StructureInfoType;
@@ -93,10 +93,10 @@ export function structureInfoFromManifest(manifestData: any): ManifestStructureI
 function recursiveExtractStructure(structure: any, itemIdToLabelMap: any): ManifestStructureInfoTree {
   let label = extractIIIFLabel(structure, "");
   let id = structure["id"];
-  let type: StructureInfoType = (structure["type"] === "Canvas") ? "Canvas" : "Structure";
+  let type: StructureInfoType = (structure["type"] === "Canvas") ? "Canvas" : "Range";
   let newItem = false;
   let items = [];
-  if (type === "Structure" && structure["items"]) {
+  if (type === "Range" && structure["items"]) {
     for (let item of structure["items"]) {
       items.push(recursiveExtractStructure(item, itemIdToLabelMap));
     }

--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -23,17 +23,17 @@ export type ManifestCanvasInfo = {
 }
 
 
-export type RangeInfoType = "Range" | "Canvas";
+export type StructureInfoType = "Structure" | "Canvas";
 
-export type ManifestRangeInfo = {
-  type: RangeInfoType;
+export type ManifestStructureInfo = {
+  type: StructureInfoType;
   label: string;
   id: string;
   newItem: boolean;
-  items: ManifestRangeInfo[];
+  items: ManifestStructureInfo[];
 }
 
-export type ManifestRangeInfoTree = ManifestRangeInfo & DataNode
+export type ManifestStructureInfoTree = ManifestStructureInfo & DataNode
 
 
 export function canvasInfoFromManifest(manifestData: any): ManifestCanvasInfo[] | null {
@@ -73,8 +73,8 @@ export function canvasInfoFromManifest(manifestData: any): ManifestCanvasInfo[] 
   return canvasInfo;
 }
 
-export function rangeInfoFromManifest(manifestData: any): ManifestRangeInfoTree[] | null {
-  let ranges: ManifestRangeInfoTree[] | null = null;
+export function structureInfoFromManifest(manifestData: any): ManifestStructureInfoTree[] | null {
+  let structures: ManifestStructureInfoTree[] | null = null;
   if (manifestData && manifestData["structures"]) {
     let itemIdToLabelMap: any = {};
     for (let item of manifestData["items"]) {
@@ -82,21 +82,21 @@ export function rangeInfoFromManifest(manifestData: any): ManifestRangeInfoTree[
       let label = extractIIIFLabel(item);
       itemIdToLabelMap[id] = label;
     }
-    ranges = [];
+    structures = [];
     for (let structure of manifestData["structures"]) {
-      ranges.push(recursiveExtractStructure(structure, itemIdToLabelMap))
+      structures.push(recursiveExtractStructure(structure, itemIdToLabelMap))
     }
   }
-  return ranges;
+  return structures;
 }
 
-function recursiveExtractStructure(structure: any, itemIdToLabelMap: any): ManifestRangeInfoTree {
+function recursiveExtractStructure(structure: any, itemIdToLabelMap: any): ManifestStructureInfoTree {
   let label = extractIIIFLabel(structure, "");
   let id = structure["id"];
-  let type: RangeInfoType = (structure["type"] === "Canvas") ? "Canvas" : "Range";
+  let type: StructureInfoType = (structure["type"] === "Canvas") ? "Canvas" : "Structure";
   let newItem = false;
   let items = [];
-  if (type === "Range" && structure["items"]) {
+  if (type === "Structure" && structure["items"]) {
     for (let item of structure["items"]) {
       items.push(recursiveExtractStructure(item, itemIdToLabelMap));
     }


### PR DESCRIPTION
- Use canvas ids instead of oids for keys so that non-management manifests can be loaded
- Added structure loading from the manifest