### PR TITLE
Refactor to use common node finding method

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { downloadManifest, setApiKeyGlobal } from './utils/ManagementUtils';
 import TopHeader from './components/TopHeader'
 import ImageCanvas from './components/ImageCanvas'
 import LaunchModal from './components/LaunchModal';
-import { canvasInfoFromManifest, ManifestCanvasInfo, ManifestStructureInfo, structureInfoFromManifest, addNewRange, allStructureIds, createNewRange, addNewCanvas, findStructureByDataNodeKey, deleteItemsById } from './utils/IIIFUtils';
+import { canvasInfoFromManifest, ManifestCanvasInfo, ManifestStructureInfo, structureInfoFromManifest, addNewRange, allStructureIds, createNewRange, addCavasesToRange, findStructureByDataNodeKey, deleteItemsById } from './utils/IIIFUtils';
 import './App.css';
 import TreeStructure from './components/TreeStructure';
 const { Sider, Content } = Layout;
@@ -115,7 +115,7 @@ function App() {
 
   const handleOnAddCanvas = () => {
     let canvasInfoSet = canvasInfo.filter((o) => selectedCanvasIds.includes(o.canvasId));
-    let newStructureInfo = addNewCanvas(structureInfo, selectedStructureIds[0], canvasInfoSet);
+    let newStructureInfo = addCavasesToRange(structureInfo, selectedStructureIds[0], canvasInfoSet);
     setStructureInfo(newStructureInfo);
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { downloadManifest, setApiKeyGlobal } from './utils/ManagementUtils';
 import TopHeader from './components/TopHeader'
 import ImageCanvas from './components/ImageCanvas'
 import LaunchModal from './components/LaunchModal';
-import { canvasInfoFromManifest, ManifestCanvasInfo, ManifestStructureInfo, structureInfoFromManifest, addNewRange, allStructureIds, createNewRange, addNewCanvas, findManifestStructureInfo, deleteItemsById } from './utils/IIIFUtils';
+import { canvasInfoFromManifest, ManifestCanvasInfo, ManifestStructureInfo, structureInfoFromManifest, addNewRange, allStructureIds, createNewRange, addNewCanvas, findStructureByDataNodeKey, deleteItemsById } from './utils/IIIFUtils';
 import './App.css';
 import TreeStructure from './components/TreeStructure';
 const { Sider, Content } = Layout;
@@ -133,8 +133,11 @@ function App() {
     if (selectedStructureIds.length !== 1) {
       return false;
     } else {
-      let selectedItem = findManifestStructureInfo(structureInfo, selectedStructureIds[0]);
-      return (selectedItem && selectedItem.type === "Range") || false;
+      let nodeIsRange = false;
+      findStructureByDataNodeKey(structureInfo, selectedStructureIds[0], (node, i, data)=>{
+        nodeIsRange = node.type === "Range";
+      });
+      return nodeIsRange;
     }
   }
 

--- a/src/components/TreeStructure.tsx
+++ b/src/components/TreeStructure.tsx
@@ -1,7 +1,7 @@
 import { Tree } from 'antd';
 import { DataNode, TreeProps } from 'antd/lib/tree';
 import React, { useState } from 'react';
-import { ManifestCanvasInfo, ManifestStructureInfo, findStructureByDataNodeKey } from '../utils/IIIFUtils';
+import { ManifestCanvasInfo, ManifestStructureInfo, findStructureByDataNodeKey, deleteItemsById } from '../utils/IIIFUtils';
 import EditableText from './EditableText';
 import { Key } from 'antd/lib/table/interface';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -155,11 +155,15 @@ function TreeStructure({ structureInfo, selectedIds, expandedIds, canvasInfo, on
     const dropPosition = info.dropPosition - Number(dropPos[dropPos.length - 1]);
 
     const data = [...structureInfo];
+    //return;
+
 
     // Find dragObject
     let dragObj: ManifestStructureInfo;
-    findStructureByDataNodeKey(data, dragKey, (item, index, arr) => {
-      arr.splice(index, 1);
+
+    // hack to keep indexes in canvas paths the same until move is complete
+    findStructureByDataNodeKey(data, dragKey, (item, index, arr) => {      
+      arr[index] = {...item, id: "DROP REMOVE", type: "Removing"};
       dragObj = item;
     });
 
@@ -195,7 +199,7 @@ function TreeStructure({ structureInfo, selectedIds, expandedIds, canvasInfo, on
         ar.splice(i! + 1, 0, dragObj!);
       }
     }
-    onChangeStructureInfo(data);
+    onChangeStructureInfo(deleteItemsById(data, ["DROP REMOVE"]));
   };
 
 

--- a/src/components/TreeStructure.tsx
+++ b/src/components/TreeStructure.tsx
@@ -1,7 +1,7 @@
 import { Tree } from 'antd';
 import { DataNode, TreeProps } from 'antd/lib/tree';
 import React, { useState } from 'react';
-import { ManifestCanvasInfo, ManifestStructureInfo } from '../utils/IIIFUtils';
+import { ManifestCanvasInfo, ManifestStructureInfo, findStructureByDataNodeKey } from '../utils/IIIFUtils';
 import EditableText from './EditableText';
 import { Key } from 'antd/lib/table/interface';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -136,26 +136,9 @@ function TreeStructure({ structureInfo, selectedIds, expandedIds, canvasInfo, on
     })
   }
 
-  const findStructureByDataNodeKey = (
-    data: ManifestStructureInfo[],
-    id: string,
-    callback: (node: ManifestStructureInfo, i: number, data: ManifestStructureInfo[]) => void,
-    canvasPath = ""
-  ) => {
-    for (let i = 0; i < data.length; i++) {
-      let key = data[i].id + (data[i].type === "Canvas" ? canvasPath + "-" + i : "");
-      if (key === id) {
-        return callback(data[i], i, data);
-      }
-      if (data[i].items) {
-        findStructureByDataNodeKey(data[i].items!, id, callback, canvasPath + "-" + i);
-      }
-    }
-  };
-
   const allowDrop: TreeProps['allowDrop'] = ({ dropNode, dropPosition }) => {
     let allow = true;
-    if (dropPosition == 0) {
+    if (dropPosition === 0) {
       findStructureByDataNodeKey(structureInfo, dropNode.key as string, (node, i, data)=>{
         if (node.type === "Canvas") {
           allow = false;

--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -21,7 +21,7 @@ export type ManifestCanvasInfo = {
   index: number;
 }
 
-export type StructureInfoType = "Range" | "Canvas";
+export type StructureInfoType = "Range" | "Canvas" | "Removing";
 
 export type ManifestStructureInfo = {
   type: StructureInfoType;

--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -96,35 +96,24 @@ export function createNewRange(): ManifestStructureInfo {
 }
 
 export function addNewRange(structureInfo: ManifestStructureInfo[], id: string): ManifestStructureInfo[] {
-  return structureInfo.map((structure) => {
-    if (structure.id === id) {
-      if (structure.type === "Range") {
-        let newItems = [...structure.items];
-        newItems.push(createNewRange());
-        return { ...structure, items: newItems };
-      } else {
-        return structure;
-      }
-    } else {
-      return { ...structure, items: addNewRange(structure.items, id) };
+  findStructureByDataNodeKey(structureInfo, id, (node, i, data) => {
+    if (node.type === "Range") {
+      let newItems = [...node.items, createNewRange()];
+      node.items = newItems;
     }
   });
+  return [...structureInfo];
 }
 
-export function addNewCanvas(structureInfo: ManifestStructureInfo[], id: string, canvasInfoSet: ManifestCanvasInfo[]): ManifestStructureInfo[] {
-  return structureInfo.map((structure) => {
-    if (structure.id === id) {
-      if (structure.type === "Range") {
-        let newItems = [...structure.items];
-        canvasInfoSet.forEach((c) => newItems.push({ id: c.canvasId, label: c.label, type: "Canvas", items: [], newItem: true }));
-        return { ...structure, items: newItems };
-      } else {
-        return structure;
-      }
-    } else {
-      return { ...structure, items: addNewCanvas(structure.items, id, canvasInfoSet) };
+export function addCavasesToRange(structureInfo: ManifestStructureInfo[], id: string, canvasInfoSet: ManifestCanvasInfo[]): ManifestStructureInfo[] {
+  findStructureByDataNodeKey(structureInfo, id, (node, i, data) => {
+    if (node.type === "Range") {
+      let newItems = [...node.items];
+      canvasInfoSet.forEach((c) => newItems.push({ id: c.canvasId, label: c.label, type: "Canvas", items: [], newItem: true }));
+      node.items = newItems;
     }
   });
+  return [...structureInfo];
 }
 
 export function deleteItemsById(structureInfo: ManifestStructureInfo[], ids: string[], canvasPath = ""): ManifestStructureInfo[] {

--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -150,19 +150,19 @@ export function allStructureIds(structureInfo: ManifestStructureInfo[] | null, i
   return ids;
 }
 
-export function findManifestStructureInfo(structureInfo: ManifestStructureInfo[], id: string): ManifestStructureInfo | null {
-  for (let info of structureInfo) {
-    if (info.id === id) {
-      return info;
+export function findStructureByDataNodeKey(data: ManifestStructureInfo[],
+  id: string,
+  callback: (node: ManifestStructureInfo, i: number, data: ManifestStructureInfo[]) => void,
+  canvasPath = "") {
+  for (let i = 0; i < data.length; i++) {
+    let key = data[i].id + (data[i].type === "Canvas" ? canvasPath + "-" + i : "");
+    if (key === id) {
+      return callback(data[i], i, data);
     }
-    else {
-      let childInfo = findManifestStructureInfo(info.items, id);
-      if (childInfo) {
-        return childInfo;
-      }
+    if (data[i].items) {
+      findStructureByDataNodeKey(data[i].items!, id, callback, canvasPath + "-" + i);
     }
   }
-  return null;
 }
 
 function recursiveExtractStructure(structure: any, itemIdToLabelMap: any): ManifestStructureInfo {


### PR DESCRIPTION
Refactor to use findStructureByDataNodeKey where possible.
findStructureByDataNodeKey if from ant d examples "loop" function.
Fix drag issue where canvas paths were changing because item was removed before move was complete.