### PR TITLE
Prevent duplicate canvases from being added to a range

### DIFF
--- a/src/utils/IIIFUtils.tsx
+++ b/src/utils/IIIFUtils.tsx
@@ -142,7 +142,10 @@ export function addCavasesToRange(structureInfo: ManifestStructureInfo[], id: st
   findStructureByKey(structureInfo, id, (structure) => {
     if (structure.type === "Range") {
       let newItems = [...structure.items];
-      canvasInfoSet.forEach((c) => newItems.push({ id: c.canvasId, label: c.label, type: "Canvas", items: [], newItem: true, key: uuidv4() }));
+      canvasInfoSet.forEach((c) => {
+        if (!newItems.find((item) => item.id === c.canvasId)) 
+          newItems.push({ id: c.canvasId, label: c.label, type: "Canvas", items: [], newItem: true, key: uuidv4() })
+      });
       structure.items = newItems;
     }
   });


### PR DESCRIPTION
## Summary
- Prevent duplicate canvases from being added to a range
- Ensure canvases can be rearranged within the range

## Related Ticket
[#2185](https://app.zenhub.com/workspaces/yul-dc-5e50083561915b11fc9e5850/issues/yalelibrary/yul-dc/2185)