### PR TITLE
Add relative homepage to package.json for deploying to sub-directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "yul-dc-structure-editor",
   "version": "0.1.0",
   "private": true,
+  "homepage": "./",
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/free-solid-svg-icons": "^6.1.2",


### PR DESCRIPTION
Adds "./" as the homepage to package.json so the app can be served from a subdirectory after it's built.

